### PR TITLE
Update SICP url, it seems to have moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ There are also meta files for some other content from outside the rationalist co
 
 * `hedonistic` - [The Hedonistic Imperative](https://www.hedweb.com/hedethic//tabconhi.htm) by David Pearce
 * `wbwelonmusk` - [Wait but Why on Elon Musk](https://waitbutwhy.com/2017/03/elon-musk-post-series.html) by Tim Urban
-* `scip` - [The Structure and Interpretation of Computer Programs](https://mitpress.mit.edu/sicp/full-text/book/)
+* `scip` - [The Structure and Interpretation of Computer Programs](https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/)
 
 So, for example:
 

--- a/meta/sicp.json
+++ b/meta/sicp.json
@@ -16,7 +16,7 @@
 		"language": "en",
 		"description": "Structure and Intrepretation of Computer Programs",
 		"contents": "Chapters",
-		"source": "https://mitpress.mit.edu/sicp/full-text/book/",
+		"source": "https://mitpress.mit.edu/sites/default/files/sicp/full-text/book/",
 		"images": []
 	},
 	"titleSelector": "h1, h2",


### PR DESCRIPTION
Seems like SICP url has changed, leading to errors:
```
Scraping https://mitpress.mit.edu/sicp/full-text/book/book-Z-H-5.html
child_process.js:644
    throw err;
    ^

Error: Command failed: wget https://mitpress.mit.edu/sicp/full-text/book/book-Z-H-5.html -nc -q -O ./cache/book-Z-H-5.html
    at checkExecSyncError (child_process.js:601:13)
    at execSync (child_process.js:641:13)
    at config.urls.forEach.url (/home/user/repos/LessWrong-Portable/build.js:56:5)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/home/user/repos/LessWrong-Portable/build.js:46:13)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
```
I search and replaced the url. Now it seems to work. Maybe a test could be added to build-pipeline that checks all books for valid urls?

But still, thanks for the great work! This program works well :+1: 
